### PR TITLE
Locale fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ limitations under the License.
 - fixed some lint problems
 - added API documentation
 - now can test on web browsers automatically
+- Fixed various bugs parsing the platform locales in getLocale()
+    * Locales with a script code such as "zh-Hans-CN"
+    * The posix "C" default locale
+    * Platforms where the region code is not upper-case
+    * Platforms that don't use a dash to separate the components
+    * Platforms that include a dot and a charset name after the specifier
 
 ### v1.0.0
 

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ let locale;
  * @private
  */
 function parseLocale(str) {
-    if (!str || str === "C") return str;
+    if (!str) return str;
 
     // take care of the libc style locale with a dot + script at the end
     var dot = str.indexOf('.')
@@ -169,6 +169,7 @@ function parseLocale(str) {
     // handle the posix default locale
     if (str === "C") return "en-US";
 
+    // full locale
     if (str.length >= 10) {
         return [
             str.substring(0,2).toLowerCase(),
@@ -177,6 +178,15 @@ function parseLocale(str) {
         ].join("-");
     }
 
+    // language + script
+    if (str.length >= 7) {
+        return [
+            str.substring(0,2).toLowerCase(),
+            str[3].toUpperCase() + str.substring(4,7).toLowerCase()
+        ].join("-");
+    }
+
+    // language + region
     if (str.length >= 5) {
         return [
             str.substring(0,2).toLowerCase(),
@@ -184,6 +194,7 @@ function parseLocale(str) {
         ].join("-");
     }
 
+    // language only
     if (str.length < 3) {
         return str.toLowerCase();
     }

--- a/test/testenv.js
+++ b/test/testenv.js
@@ -160,10 +160,10 @@ module.exports.testglobal = {
         
         test.expect(1);
         test.equal(ilibEnv.getLocale(), "th-TH");
-        test.done();
         
         process.env.LANG = "";
         ilibEnv.clearCache();
+        test.done();
     },
     
     testGetLocaleNodejs2: function(test) {
@@ -179,10 +179,67 @@ module.exports.testglobal = {
         
         test.expect(1);
         test.equal(ilibEnv.getLocale(), "th-TH");
-        test.done();
         
         process.env.LC_ALL = "";
         ilibEnv.clearCache();
+        test.done();
+    },
+
+    testGetLocaleNodejsFullLocale: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+
+        process.env.LC_ALL = "zh-Hans-CN";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-Hans-CN");
+        test.done();
+
+        process.env.LC_ALL = "";
+        ilibEnv.clearCache();
+    },
+
+    testGetLocaleNodejsLangScript: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+
+        process.env.LC_ALL = "zh-Hans";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-Hans");
+
+        process.env.LC_ALL = "";
+        ilibEnv.clearCache();
+        test.done();
+    },
+
+    testGetLocaleNodejsLangOnly: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+
+        process.env.LC_ALL = "zh";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh");
+
+        process.env.LC_ALL = "";
+        ilibEnv.clearCache();
+        test.done();
     },
 
     testGetLocaleNodejsPosixLocale: function(test) {
@@ -198,10 +255,10 @@ module.exports.testglobal = {
 
         test.expect(1);
         test.equal(ilibEnv.getLocale(), "en-US");
-        test.done();
 
         process.env.LC_ALL = "";
         ilibEnv.clearCache();
+        test.done();
     },
 
     testGetLocaleNodejsPosixLocaleFull: function(test) {
@@ -217,10 +274,10 @@ module.exports.testglobal = {
 
         test.expect(1);
         test.equal(ilibEnv.getLocale(), "en-US");
-        test.done();
 
         process.env.LC_ALL = "";
         ilibEnv.clearCache();
+        test.done();
     },
 
     testGetLocaleSimulateRhino: function(test) {

--- a/test/testenv.js
+++ b/test/testenv.js
@@ -184,16 +184,503 @@ module.exports.testglobal = {
         process.env.LC_ALL = "";
         ilibEnv.clearCache();
     },
-    
+
+    testGetLocaleNodejsPosixLocale: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+
+        process.env.LC_ALL = "C";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "en-US");
+        test.done();
+
+        process.env.LC_ALL = "";
+        ilibEnv.clearCache();
+    },
+
+    testGetLocaleNodejsPosixLocaleFull: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+
+        process.env.LC_ALL = "C.UTF8";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "en-US");
+        test.done();
+
+        process.env.LC_ALL = "";
+        ilibEnv.clearCache();
+    },
+
+    testGetLocaleSimulateRhino: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("rhino");
+
+        global.environment = {
+            user: {
+                language: "de",
+                country: "AT"
+            }
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "de-AT");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.environment = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme1: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("trireme");
+
+        process.env.LANG = "de-AT";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "de-AT");
+
+        // clean up
+        ilibEnv.clearCache();
+        process.env.LANG = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme2: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("trireme");
+
+        process.env.LANGUAGE = "de-AT";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "de-AT");
+
+        // clean up
+        ilibEnv.clearCache();
+        process.env.LANGUAGE = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTrireme3: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("trireme");
+
+        process.env.LC_ALL = "de-AT";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "de-AT");
+
+        // clean up
+        ilibEnv.clearCache();
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTriremeFullSpecifier: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("trireme");
+
+        process.env.LC_ALL = "de_DE.UTF8";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "de-DE");
+
+        // clean up
+        ilibEnv.clearCache();
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateTriremeFullLocale: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("trireme");
+
+        process.env.LC_ALL = "zh-Hans-CN";
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilibEnv.clearCache();
+        process.env.LC_ALL = "";
+
+        test.done();
+    },
+
+    testGetLocaleSimulateWebOS: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("webos");
+
+        global.PalmSystem = {
+            locale: "ru-RU"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ru-RU");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.PalmSystem = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateWebOSWebapp: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in node
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("webos-webapp");
+
+        global.PalmSystem = {
+            locale: "ru-RU"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ru-RU");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.PalmSystem = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowser: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja-JP"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ja-JP");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserLangOnly: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ja");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserFullLocale: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            language: "zh-Hans-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateRegularBrowserNonBCP47: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            language: "ja_jp"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ja-JP");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser1: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            browserLanguage: "ja-JP"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ja-JP");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser2: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            userLanguage: "ko-KR"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "ko-KR");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowser3: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-CN");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowserNonBCP: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh_cn"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-CN");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateIEBrowserFull: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("browser");
+
+        var loc = "";
+
+        global.navigator = {
+            systemLanguage: "zh-Hans-CN"
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "zh-Hans-CN");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.navigator = undefined;
+
+        test.done();
+    },
+
+    testGetLocaleSimulateQt: function(test) {
+        if (ilibEnv.getPlatform() !== "nodejs") {
+            // only test this in nodejs
+            test.done();
+            return;
+        }
+
+        ilibEnv.clearCache();
+        ilibEnv.setPlatform("qt");
+
+        var loc = "";
+
+        global.Qt = {
+            locale: function() {
+                return {
+                    name: "fr-FR"
+                };
+            }
+        };
+
+        test.expect(1);
+        test.equal(ilibEnv.getLocale(), "fr-FR");
+
+        // clean up
+        ilibEnv.clearCache();
+        global.Qt = undefined;
+
+        test.done();
+    },
+
     testGetLocaleRhino: function(test) {
         if (ilibEnv.getPlatform() !== "rhino") {
             // only test this in node
             test.done();
             return;
         }
-        
+
         ilibEnv.clearCache();
-        
+
         if (typeof(process) === 'undefined') {
             // under plain rhino
             environment.user.language = "de";


### PR DESCRIPTION
* Fixed various bugs parsing the platform locales in ilib.getLocale()
     * Locales with a script code such as "zh-Hans-CN"
     * The posix "C" default locale
     * Platforms where the region code is not upper-case
     * Platforms that don't use a dash to separate the components
     * Platforms that include a dot and a charset name after the specifier
* Same fixes as in ilib itself