### PR TITLE
Update to detect webOS platform with webOSSystem value

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ limitations under the License.
 
 ## Release Notes
 
-### v1.3.4
+### v1.4.0
 * Update to detect webOS platform with webOSSystem value.
 
 ### v1.3.3

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ if (ilibEnv.isGlobal("variableName")) {
 
 ## License
 
-Copyright © 2021-2023, JEDLSoft
+Copyright © 2021-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -202,6 +202,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v1.3.4
+* Update to detect webOS platform with webOSSystem value.
 
 ### v1.3.3
 

--- a/package.json
+++ b/package.json
@@ -69,16 +69,17 @@
         "debug:web": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/karma start --reporters dots",
         "clean": "git clean -f -d src test; rm -rf lib",
         "doc": "mkdir -p docs ; jsdoc2md -c jsdoc.json --separators --source src/* -m table > docs/ilibEnv.md",
-        "doc:html": "jsdoc -c jsdoc.json"
+        "doc:html": "jsdoc -c jsdoc.json",
+        "prepare": "conditional-install"
     },
     "devDependencies": {
         "@babel/core": "^7.23.5",
         "@babel/preset-env": "^7.23.5",
         "@babel/register": "^7.22.15",
         "@babel/runtime": "^7.23.5",
-        "babel-loader": "^8.3.0",
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-module-resolver": "^5.0.0",
+        "conditional-install": "^1.0.1",
         "docdash": "^2.0.2",
         "expect": "^29.7.0",
         "grunt": "^1.6.1",
@@ -96,10 +97,23 @@
         "karma-assert": "^1.0.1",
         "karma-chrome-launcher": "^3.2.0",
         "karma-jasmine": "^5.1.0",
-        "karma-webpack": "^5.0.0",
         "load-grunt-tasks": "^5.1.0",
-        "npm-run-all": "^4.1.5",
-        "webpack": "^5.89.0",
-        "webpack-cli": "^5.1.4"
+        "npm-run-all": "^4.1.5"
+    },
+    "conditionalDependencies": {
+        "process.versions.node < v14.0.0": {
+            "babel-loader": "^8.0.0",
+            "jest": "^26.0.0",
+            "karma-webpack": "^4.0.0",
+            "webpack": "^4.0.0",
+            "webpack-cli": "^4.0.0"
+        },
+        "process.versions.node >= v14.0.0": {
+            "babel-loader": "^9.0.0",
+            "jest": "^29.7.0",
+            "karma-webpack": "^5.0.0",
+            "webpack": "^5.89.0",
+            "webpack-cli": "^5.1.4"
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-env",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-env",
-    "version": "1.3.4",
+    "version": "1.4.0",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /*
  * index.js - detect various things in the runtime environment
  *
- * Copyright © 2021-2023, JEDLSoft
+ * Copyright © 2021-2024, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ function getPlatformValue() {
         return "nodejs";
     } else if (typeof(Qt) !== 'undefined') {
         return "qt";
-    } else if (typeof(PalmSystem) !== 'undefined') {
+    } else if ((typeof(PalmSystem) !== 'undefined')|| (typeof(webOSSystem) !== 'undefined'))  {
         return (typeof(window) !== 'undefined') ? "webos-webapp" : "webos";
     } else if (typeof(window) !== 'undefined') {
         return "browser";
@@ -260,6 +260,8 @@ export function getLocale() {
                     globalScope.locale = parseLocale(PalmSystem.locales.UI);
                 } else if (typeof(PalmSystem.locale) !== 'undefined') {
                     globalScope.locale = parseLocale(PalmSystem.locale);
+                } else if (typeof(webOSSystem.locale) !== 'undefined') {
+                    ilib.locale = parseLocale(webOSSystem.locale);
                 } else {
                     globalScope.locale = undefined;
                 }
@@ -340,7 +342,7 @@ export function getTimeZone() {
                 return globalScope.tz;
             }
         }
-        let timezone;
+        let timezone, timeZone;
 
         switch (getPlatform()) {
             case 'browser':
@@ -354,7 +356,8 @@ export function getTimeZone() {
             case 'webos':
                 // running in webkit on webOS
                 ({ timezone } = PalmSystem);
-                if (timezone && timezone.length > 0) {
+                ({ timeZone } = webOSSystem);
+                if ((timezone && timezone.length > 0) || (timeZone && timeZone.length > 0)) {
                     tz = timezone;
                 }
                 break;


### PR DESCRIPTION
Updated to detect the webOS Platform as webOSSystem value. The PalmSystem has been renamed to webOSSystem
Currently, we keep both webOSSystem and PalmSystem. but we don't know when the PalmSystem will disappear.